### PR TITLE
Amazon Linux support

### DIFF
--- a/tasks/amazon.yml
+++ b/tasks/amazon.yml
@@ -1,0 +1,12 @@
+- name: "Ensure image manipulation libraries are installed"
+  yum: >
+    name={{ item }}
+    state=present
+  with_items:
+    - GraphicsMagick
+    - GraphicsMagick-devel
+    - cairo-devel
+    - libjpeg-turbo-devel
+  tags:
+    - image-manipulation
+    - pkgs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 - include: centos.yml
   when: ansible_distribution == 'CentOS'
 
+- include: amazon.yml
+  when: ansible_distribution == 'Amazon'
+
 - include: debian.yml
   when: ansible_distribution == 'Debian'


### PR DESCRIPTION
The Amazon repo already has an up to date Imagemagick, no need to use EPEL
